### PR TITLE
css: do better on ultrawides and narrow screens

### DIFF
--- a/files/static/style.css
+++ b/files/static/style.css
@@ -4,7 +4,6 @@ html {
   margin: 20px auto;
   /* make sure the scrollbar is always shown so
      the width doesnt change between pages */
-  font-size: calc(12px + 0.5vw);
   overflow-y: scroll;
 }
 
@@ -31,8 +30,8 @@ ul a:hover li {
 
 ul {
   list-style-type: none;
-  padding-left: 30px;
-  padding-right: 30px;
+  padding-left: 0;
+  padding-right: 0;
 }
 
 ul li {


### PR DESCRIPTION
Because `max-width` is set in pixels, and `font-size` is relative to the display width, as the screen gets wider, the *less* characters fit on a line. This gets especially absurd on ultrawide displays - I only get 20 giant characters per line on mine.

AFAIK the default font size should always be readable, so I just removed the explicit `font-size` completely, which fixes the issue. `max-width` could also be changed to be measured in `ch`, to make the characters/line consistent across fonts.

I also removed the `ul` padding. It doesn't really do anything on large screens, and I think the additional space on narrow screens is worth it.